### PR TITLE
Fix styles for CKAN 2.8

### DIFF
--- a/ckanext/showcase/plugin.py
+++ b/ckanext/showcase/plugin.py
@@ -145,16 +145,16 @@ class ShowcasePlugin(plugins.SingletonPlugin, lib_plugins.DefaultDatasetForm):
             m.connect('ckanext_showcase_delete', '/showcase/delete/{id}',
                       action='delete')
             m.connect('ckanext_showcase_read', '/showcase/{id}', action='read',
-                      ckan_icon='picture')
+                      ckan_icon='picture-o')
             m.connect('ckanext_showcase_edit', '/showcase/edit/{id}',
                       action='edit', ckan_icon='edit')
             m.connect('ckanext_showcase_manage_datasets',
                       '/showcase/manage_datasets/{id}',
                       action="manage_datasets", ckan_icon="sitemap")
             m.connect('dataset_showcase_list', '/dataset/showcases/{id}',
-                      action='dataset_showcase_list', ckan_icon='picture')
+                      action='dataset_showcase_list', ckan_icon='picture-o')
             m.connect('ckanext_showcase_admins', '/ckan-admin/showcase_admins',
-                      action='manage_showcase_admins', ckan_icon='picture'),
+                      action='manage_showcase_admins', ckan_icon='picture-o'),
             m.connect('ckanext_showcase_admin_remove',
                       '/ckan-admin/showcase_admin_remove',
                       action='remove_showcase_admin')

--- a/ckanext/showcase/templates/admin/confirm_remove_showcase_admin.html
+++ b/ckanext/showcase/templates/admin/confirm_remove_showcase_admin.html
@@ -5,7 +5,7 @@
 {% block maintag %}<div class="row" role="main">{% endblock %}
 
 {% block main_content %}
-  <section class="module span6 offset3">
+  <section class="module col-md-6 col-md-offset-3">
     <div class="module-content">
       {% block form %}
         <p>{{ _('Are you sure you want to remove this user as a Showcase Admin - {name}?').format(name=c.user_dict.name) }}</p>

--- a/ckanext/showcase/templates/showcase/add_datasets.html
+++ b/ckanext/showcase/templates/showcase/add_datasets.html
@@ -4,7 +4,7 @@
 
 {% block wrapper_class %} ckanext-showcase-edit-wrapper{% endblock %}
 
-{% block ckanext_showcase_edit_span %}span12{% endblock %}
+{% block ckanext_showcase_edit_span %}col-md-12{% endblock %}
 
 {% block primary_content_inner %}
   <section class="module">

--- a/ckanext/showcase/templates/showcase/confirm_delete.html
+++ b/ckanext/showcase/templates/showcase/confirm_delete.html
@@ -5,7 +5,7 @@
 {% block maintag %}<div class="row" role="main">{% endblock %}
 
 {% block main_content %}
-  <section class="module span6 offset3">
+  <section class="module col-md-6 col-md-offset-3">
     <div class="module-content">
       {% block form %}
         <p>{{ _('Are you sure you want to delete showcase - {showcase_name}?').format(showcase_name=c.pkg_dict.name) }}</p>

--- a/ckanext/showcase/templates/showcase/edit.html
+++ b/ckanext/showcase/templates/showcase/edit.html
@@ -2,7 +2,7 @@
 
 {% block wrapper_class %} ckanext-showcase-edit-wrapper{% endblock %}
 
-{% block ckanext_showcase_edit_span %}span12{% endblock %}
+{% block ckanext_showcase_edit_span %}col-md-12{% endblock %}
 
 {% block primary_content_inner %}
   {% block form %}

--- a/ckanext/showcase/templates/showcase/edit_base.html
+++ b/ckanext/showcase/templates/showcase/edit_base.html
@@ -24,7 +24,7 @@
 {% endblock %}
 
 {% block primary %}
-  <div class="primary {% block ckanext_showcase_edit_span %}span9{% endblock %}">
+  <div class="primary {% block ckanext_showcase_edit_span %}col-md-9{% endblock %}">
     {% block primary_content %}
       <article class="module">
         {% block page_header %}

--- a/ckanext/showcase/templates/showcase/manage_datasets.html
+++ b/ckanext/showcase/templates/showcase/manage_datasets.html
@@ -4,7 +4,7 @@
 
 {% block wrapper_class %} ckanext-showcase-edit-wrapper{% endblock %}
 
-{% block ckanext_showcase_edit_span %}span12{% endblock %}
+{% block ckanext_showcase_edit_span %}col-md-12{% endblock %}
 
 {% block ckanext_showcase_edit_module_content_class %}{% endblock %}
 
@@ -31,7 +31,7 @@
     </div>
 
     <div class="row row2">
-      <section class="span6">
+      <section class="col-md-6">
         <div class="module-content">
           <h3 class="page-heading">{{ _('Datasets available to add to this showcase') }}</h3>
           {% block package_search_results_list %}
@@ -91,7 +91,7 @@
         </div>
       </section>
 
-      <section class="span6">
+      <section class="col-md-6">
         <div class="module-content">
           <h3 class="page-heading">{{ _('Datasets in this showcase') }}</h3>
           {% if c.showcase_pkgs %}


### PR DESCRIPTION
### Overview

CKAN 2.8 moved to Bootstrap 3, but `ckanext-showcase` hasn't been updated.  This updates the `span` and `offset` classes to their Bootstrap 3 equivalents (using `-md-`, which seemed reasonable).

It also fixes the icon, which for some reason has an `-o` on the end now in the CKAN Font Awesome setup.

### Notes

I didn't do a comprehensive review of everything that might have been affected by the switch, but I changed what I knew to look for and the results seem reasonable to me.  Hopefully this will get updated upstream at some point and we can throw away this fork.

### Testing

Go to https://github.com/azavea/opendataphilly-ckan/pull/81 to see it in action.